### PR TITLE
more abstract support for fetching files

### DIFF
--- a/ghcjs-fetch.cabal
+++ b/ghcjs-fetch.cabal
@@ -19,7 +19,7 @@ library
                        GHCJS.Fetch.FFI
                        GHCJS.Fetch.Types
                        GHCJS.Fetch.ByteString
-  build-depends:       aeson >= 1.1 && <= 1.4
+  build-depends:       aeson >= 1.1 && <= 1.5
                      , base >= 4.9 && < 5
                      , bytestring >= 0.10 && < 0.11
                      , case-insensitive >= 1.2 && < 1.3

--- a/ghcjs-fetch.cabal
+++ b/ghcjs-fetch.cabal
@@ -1,5 +1,5 @@
 name:                ghcjs-fetch
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            GHCJS bindings for the JavaScript Fetch API
 homepage:            https://github.com/cocreature/ghcjs-fetch#readme
 license:             BSD3
@@ -11,18 +11,20 @@ category:            Web
 build-type:          Simple
 extra-source-files:  README.md
 cabal-version:       >=1.10
-tested-with:         GHC == 8.0.2
+tested-with:         GHC == 8.4.2
 
 library
   hs-source-dirs:      src
   exposed-modules:     GHCJS.Fetch
                        GHCJS.Fetch.FFI
                        GHCJS.Fetch.Types
-  build-depends:       aeson >= 1.1 && < 1.3
+                       GHCJS.Fetch.ByteString
+  build-depends:       aeson >= 1.1 && <= 1.4
                      , base >= 4.9 && < 5
                      , bytestring >= 0.10 && < 0.11
                      , case-insensitive >= 1.2 && < 1.3
                      , http-types >= 0.9 && < 0.13
+                     , binary
   if impl(ghcjs)
     build-depends:     ghcjs-base
   else

--- a/src/GHCJS/Fetch.hs
+++ b/src/GHCJS/Fetch.hs
@@ -37,6 +37,9 @@ module GHCJS.Fetch
   -- * Response
   , responseJSON
   , responseText
+  , responseBlob
+  , responseMutableArrayBuffer
+  , responseArrayBuffer
   -- * Exceptions
   , JSPromiseException(..)
   ) where
@@ -57,7 +60,7 @@ import qualified JavaScript.Object as Object
 import           JavaScript.Object.Internal (Object(..))
 import           Network.HTTP.Types
 import           System.IO.Unsafe
-
+import           JavaScript.TypedArray.ArrayBuffer (ArrayBuffer (..),MutableArrayBuffer (..), unsafeFreeze)
 import           GHCJS.Fetch.FFI
 import           GHCJS.Fetch.Types
 
@@ -258,6 +261,18 @@ responseJSON resp = fromJSValUnchecked =<< await =<< js_responseJSON resp
 responseText :: JSResponse -> IO JSString
 responseText resp =
   fromJSValUnchecked =<< await =<< js_responseText resp
+
+responseBlob :: JSResponse -> IO JSVal
+responseBlob resp =
+  fromJSValUnchecked =<< await =<< js_responseBlob resp
+ 
+responseMutableArrayBuffer :: JSResponse -> IO MutableArrayBuffer
+responseMutableArrayBuffer resp =
+  pFromJSVal <$> (await =<< js_responseMutableArrayBuffer resp)
+
+responseArrayBuffer :: JSResponse -> IO ArrayBuffer
+responseArrayBuffer resp =
+  unsafeFreeze =<< responseMutableArrayBuffer resp
 
 await :: JSPromise a -> IO JSVal
 await p = do

--- a/src/GHCJS/Fetch/ByteString.hs
+++ b/src/GHCJS/Fetch/ByteString.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module GHCJS.Fetch.ByteString where
+
+import GHCJS.Fetch
+import GHCJS.Fetch.FFI
+import GHCJS.Fetch.Types
+import GHCJS.Buffer
+import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer (..),MutableArrayBuffer (..),unsafeFreeze)
+import Data.Binary
+import Data.ByteString (ByteString(..))
+import qualified Data.ByteString.Lazy as BL
+import Data.String
+
+fetchByteString :: Request -> IO ByteString
+fetchByteString req = do
+    response <- fetch req
+    arr <- responseArrayBuffer response
+    let bs = toByteString 0 Nothing $ createFromArrayBuffer arr
+    return bs
+
+fetchBinary :: Binary a => Request -> IO a
+fetchBinary req = do
+    bs <- fetchByteString req
+    return $ decode (BL.fromStrict bs)
+    
+fetchBinaryFile :: Binary a => FilePath -> IO a
+fetchBinaryFile = fetchBinaryFileWith opts
+    where opts = defaultRequestOptions { reqOptHeaders = [("origin","http://anywhere.com")] }
+
+fetchBinaryFileWith :: Binary a => RequestOptions -> FilePath -> IO a
+fetchBinaryFileWith opts file = do
+    let url = fromString file
+    let req = Request url opts
+    fetchBinary req

--- a/src/GHCJS/Fetch/FFI.hs
+++ b/src/GHCJS/Fetch/FFI.hs
@@ -6,6 +6,8 @@ module GHCJS.Fetch.FFI
   , js_fetch
   , js_responseJSON
   , js_responseText
+  , js_responseBlob
+  , js_responseMutableArrayBuffer
   , js_newHeaders
   , js_appendHeader
   ) where
@@ -14,6 +16,7 @@ import GHC.Stack
 import GHCJS.Fetch.Types
 import GHCJS.Types
 import JavaScript.Object
+import JavaScript.TypedArray.ArrayBuffer (ArrayBuffer (..),MutableArrayBuffer (..))
 
 #ifdef ghcjs_HOST_OS
 foreign import javascript safe "new Request($1, $2)" js_newRequest
@@ -31,6 +34,12 @@ foreign import javascript safe "$1.json()" js_responseJSON ::
 
 foreign import javascript safe "$1.text()" js_responseText ::
                JSResponse -> IO (JSPromise JSString)
+
+foreign import javascript safe "$1.blob()" js_responseBlob ::
+               JSResponse -> IO (JSPromise JSVal)
+
+foreign import javascript safe "$1.arrayBuffer()" js_responseMutableArrayBuffer ::
+               JSResponse -> IO (JSPromise MutableArrayBuffer)
 
 foreign import javascript safe "new Headers()" js_newHeaders ::
                IO JSHeaders
@@ -57,6 +66,12 @@ js_responseJSON = ghcjsOnly
 
 js_responseText :: JSResponse -> IO (JSPromise JSString)
 js_responseText = ghcjsOnly
+
+js_responseBlob :: JSResponse -> IO (JSPromise JSVal)
+js_responseBlob = ghcjsOnly
+
+js_responseMutableArrayBuffer :: JSResponse -> IO (JSPromise MutableArrayBuffer)
+js_responseMutableArrayBuffer = ghcjsOnly
 
 js_newHeaders :: IO JSHeaders
 js_newHeaders = ghcjsOnly


### PR DESCRIPTION
This was just something that I needed and found no direct support for.
Since it is slightly more abstract than the JS API itself, I put it into a separate module, but I believe that it would be more convenient for users and useful as part  of ghcjs-fetch.
Cheers,
hugo